### PR TITLE
Fix fine fuel moisture code calculation

### DIFF
--- a/src/FireClimate.cs
+++ b/src/FireClimate.cs
@@ -85,7 +85,7 @@ namespace Landis.Library.Climate
             if (mo > Ed)
                 return Ed + (mo - Ed) * Math.Pow(10.0, -kd);
 
-            return (mo < Ed && mo < Ew) ? (Ew - mo) * Math.Pow(10.0, -kw) : mo;
+            return (mo < Ed && mo < Ew) ? Ew - (Ew - mo) * Math.Pow(10.0, -kw) : mo;
         }
 
         private static double Calculate_FineFuelMoistureCode(double m) => Math.Min(100.0, 59.5 * (250.0 - m) / (147.2 + m));


### PR DESCRIPTION
Climate v5 has been producing higher values for FFMC and thus substantially higher FWI than previous versions. It looks like the code for equation 8 to calculate `m` should be `(mo < Ed && mo < Ew) ? Ew - (Ew - mo) * Math.Pow(10.0, -kw) : mo` as in the [previous version of FireClimate.cs](https://github.com/LANDIS-II-Foundation/Library-Climate/blob/c05e3866f00b227de80d37e866f967afcc4c1a49/FireClimate.cs#L391) and [the equivalent code in the `cffrds` R package.](https://github.com/cffdrs/cffdrs_r/blob/4e40dd3af841f3a708abd83d7f2d43fefb08649a/R/fine_fuel_moisture_code.r#L66) 

I've tested it and this change brings calculated FWI down to the range of values I was getting from Climate v4 and `cffrds`. 

<img width="1549" height="401" alt="image" src="https://github.com/user-attachments/assets/e6a846f4-de9f-4321-b189-6cba458bd1cb" />
